### PR TITLE
client: allow passing a string for the channels option.

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -13,7 +13,7 @@ var client = function client(opts) {
     this.setMaxListeners(0);
 
     this.opts = _.get(opts, {});
-    this.opts.channels = this.opts.channels || [];
+    this.opts.channels = this.opts.channels || this.opts.channel || [];
     this.opts.connection = this.opts.connection || {};
     this.opts.identity = this.opts.identity || {};
     this.opts.options = this.opts.options || {};
@@ -54,6 +54,17 @@ var client = function client(opts) {
     this.log = this.opts.logger || logger;
 
     try { logger.setLevel(level); } catch(e) {};
+
+    // If a string is passed here, format it..
+    if(_.isString(this.opts.channels)) {
+        // Comma-delimited channels..
+        if(this.opts.channels.indexOf(",") > -1) {
+            this.opts.channels = this.opts.channels.split(",");
+        }
+        else {
+            this.opts.channels = [this.opts.channels];
+        }
+    }
 
     // Format the channel names..
     this.opts.channels.forEach(function(part, index, theArray) {


### PR DESCRIPTION
Can either be a single channel or a comma-delimited list of channels.