### PR TITLE
Improvement: Output the login-name alongside of the username for resubscription notices

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -570,8 +570,8 @@ client.prototype.handleMessage = function handleMessage(message) {
                         var months = _.get(~~message.tags["msg-param-months"], null);
 
                         this.emits(["resub", "subanniversary"], [
-                            [channel, username, months, msg],
-                            [channel, username, months, msg]
+                            [channel, username, months, msg, message.tags],
+                            [channel, username, months, msg, message.tags]
                         ]);
                     }
                     break;
@@ -800,7 +800,7 @@ client.prototype.handleMessage = function handleMessage(message) {
                         if (msg.includes("subscribed to")) {
                           // Ignore this feature.
                         }
-                        
+
                         else if (msg.includes("just subscribed")) {
                             this.emit("subscription", channel, msg.split(" ")[0]);
                         }


### PR DESCRIPTION
When handling automated actions for your Users the login name is (way more) useful for that than the username, especially if that one is localized.

Seeing as the Info is there, but just not emitted i think it would be useful to output that, at least for resubs.