### PR TITLE
client: set custom Client-ID for emotesets API call

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -13,13 +13,12 @@ var client = function client(opts) {
     this.setMaxListeners(0);
 
     this.opts = _.get(opts, {});
-    this.opts.general = this.opts.general || {};
     this.opts.channels = this.opts.channels || [];
     this.opts.connection = this.opts.connection || {};
     this.opts.identity = this.opts.identity || {};
     this.opts.options = this.opts.options || {};
     
-    this.clientId = _.get(this.opts.general.clientId, null);
+    this.clientId = _.get(this.opts.options.clientId, null);
 
     this.maxReconnectAttempts = _.get(this.opts.connection.maxReconnectAttempts, Infinity);
     this.maxReconnectInterval = _.get(this.opts.connection.maxReconnectInterval, 30000);

--- a/lib/client.js
+++ b/lib/client.js
@@ -13,10 +13,13 @@ var client = function client(opts) {
     this.setMaxListeners(0);
 
     this.opts = _.get(opts, {});
+    this.opts.general = this.opts.general || {};
     this.opts.channels = this.opts.channels || [];
     this.opts.connection = this.opts.connection || {};
     this.opts.identity = this.opts.identity || {};
     this.opts.options = this.opts.options || {};
+    
+    this.clientId = _.get(this.opts.general.clientId, null);
 
     this.maxReconnectAttempts = _.get(this.opts.connection.maxReconnectAttempts, Infinity);
     this.maxReconnectInterval = _.get(this.opts.connection.maxReconnectInterval, 30000);
@@ -1080,7 +1083,10 @@ client.prototype._updateEmoteset = function _updateEmoteset(sets) {
 
     this.api({
         url: `/chat/emoticon_images?emotesets=${sets}`,
-        headers: { "Authorization": `OAuth ${_.password(_.get(this.opts.identity.password, "")).replace("oauth:", "")}` }
+        headers: { 
+            "Authorization": `OAuth ${_.password(_.get(this.opts.identity.password, "")).replace("oauth:", "")}`,
+            "Client-ID": this.clientId
+        }
     }, (err, res, body) => {
         if (!err) { return this.emotesets = body["emoticon_sets"] || {}; }
         setTimeout(() => { this._updateEmoteset(sets); }, 60000);


### PR DESCRIPTION
A Client ID is required for the emotesets API request - suggest a 'General' category that allows users to set their `clientId` to prevent the request from failing.