### PR TITLE
client: added 3rd parameter to subscription callback thats contains an amazon prime sub boolean

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -793,7 +793,7 @@ client.prototype.handleMessage = function handleMessage(message) {
                         }
                         
                         else if (msg.includes("just subscribed")) {
-                            this.emit("subscription", channel, msg.split(" ")[0], msg.includes("Twitch Prime!"));
+                            this.emit("subscription", channel, msg.split(" ")[0], { prime: msg.includes("Twitch Prime!") });
                         }
                     }
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -793,7 +793,7 @@ client.prototype.handleMessage = function handleMessage(message) {
                         }
                         
                         else if (msg.includes("just subscribed")) {
-                            this.emit("subscription", channel, msg.split(" ")[0]);
+                            this.emit("subscription", channel, msg.split(" ")[0], msg.includes("Twitch Prime!"));
                         }
                     }
 


### PR DESCRIPTION
Originally I was just passing the boolean as a 3rd parameter but figured it would be cleaner for future compatibility if we passed an object.  That way if Twitch adds any more things like this, we can just add the  value to the object instead of A) passing it as a 4th param or B) instituting a breaking change by changing the boolean to an object.

Will update docs if merged.