### PR TITLE
client: added twitch prime method to resub event

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -553,8 +553,8 @@ client.prototype.handleMessage = function handleMessage(message) {
                         var months = _.get(~~message.tags["msg-param-months"], null);
 
                         this.emits(["resub", "subanniversary"], [
-                            [channel, username, months, msg],
-                            [channel, username, months, msg]
+                            [channel, username, months, msg, { prime: msg.includes("Twitch Prime") }],
+                            [channel, username, months, msg, { prime: msg.includes("Twitch Prime") }]
                         ]);
                     }
                     break;


### PR DESCRIPTION
Added a 5th parameter to the resub event as you are able to resub with Twitch Prime as well. The message is: ``DBKynd just subscribed with Twitch Prime. DBKynd subscribed for 9 months in a row!``

Followed the same format as tmijs/tmi.js#180

Getting a lot of parameters on this event now... :(