### PR TITLE
client: add userstate to resub events - fixes #191

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -551,10 +551,15 @@ client.prototype.handleMessage = function handleMessage(message) {
                     if (msgid === "resub") {
                         var username = message.tags["display-name"] || message.tags["login"];
                         var months = _.get(~~message.tags["msg-param-months"], null);
+                        var userstate = null;
+                        if (msg) {
+                            userstate = message.tags;
+                            userstate['message-type'] = 'resub';
+                        }
 
                         this.emits(["resub", "subanniversary"], [
-                            [channel, username, months, msg],
-                            [channel, username, months, msg]
+                            [channel, username, months, msg, userstate],
+                            [channel, username, months, msg, userstate]
                         ]);
                     }
                     break;

--- a/test/events.js
+++ b/test/events.js
@@ -206,7 +206,7 @@ var events = [{
             'msg-param-months': '6',
             'room-id': '20624989',
             subscriber: false,
-            'system-msg': 'Schmoopiie\\shas\\ssubscribed\\sfor\\s6\\smonths!',
+            'system-msg': 'Schmoopiieshasssubscribedsfors6smonths!',
             turbo: true,
             'user-id': '20624989',
             'user-type': 'staff'
@@ -234,7 +234,7 @@ var events = [{
             'msg-param-months': '6',
             'room-id': '20624989',
             subscriber: false,
-            'system-msg': 'Schmoopiie\\shas\\ssubscribed\\sfor\\s6\\smonths!',
+            'system-msg': 'Schmoopiieshasssubscribedsfors6smonths!',
             turbo: true,
             'user-id': '20624989',
             'user-type': 'staff'

--- a/test/events.js
+++ b/test/events.js
@@ -186,15 +186,15 @@ var events = [{
     ]
 }, {
     name: 'subanniversary',
-    data: '@badges=staff/1,broadcaster/1,turbo/1;color=#008000;display-name=Schmoopiie;emotes=;mod=0;msg-id=resub;msg-param-months=6;room-id=20624989;subscriber=0;system-msg=Schmoopiie\shas\ssubscribed\sfor\s6\smonths!;login=schmoopiie;turbo=1;user-id=20624989;user-type=staff :tmi.twitch.tv USERNOTICE #schmoopiie :Great stream -- keep it up!',
+    data: '@badges=staff/1,subscriber/6,turbo/1;color=#008000;display-name=Schmoopiie;emotes=;mod=0;msg-id=resub;msg-param-months=6;room-id=20624989;subscriber=0;system-msg=Schmoopiie\\shas\\ssubscribed\\sfor\\s6\\smonths!;login=schmoopiie;turbo=1;user-id=20624989;user-type=staff :tmi.twitch.tv USERNOTICE #schmoopiie :Great stream -- keep it up!',
     expected: [
         '#schmoopiie',
         'Schmoopiie',
         6,
         'Great stream -- keep it up!',
         {
-            badges: { broadcaster: '1', staff: '1', turbo: '1' },
-            'badges-raw': 'staff/1,broadcaster/1,turbo/1',
+            badges: { staff: '1', subscriber: '6', turbo: '1' },
+            'badges-raw': 'staff/1,subscriber/6,turbo/1',
             color: '#008000',
             'display-name': 'Schmoopiie',
             emotes: null,
@@ -205,8 +205,8 @@ var events = [{
             'msg-id': 'resub',
             'msg-param-months': '6',
             'room-id': '20624989',
-            subscriber: false,
-            'system-msg': 'Schmoopiieshasssubscribedsfors6smonths!',
+            subscriber: true,
+            'system-msg': 'Schmoopiie has subscribed for 6 months!',
             turbo: true,
             'user-id': '20624989',
             'user-type': 'staff'
@@ -214,15 +214,15 @@ var events = [{
     ]
 }, {
     name: 'resub',
-    data: '@badges=staff/1,broadcaster/1,turbo/1;color=#008000;display-name=Schmoopiie;emotes=;mod=0;msg-id=resub;msg-param-months=6;room-id=20624989;subscriber=0;system-msg=Schmoopiie\shas\ssubscribed\sfor\s6\smonths!;login=schmoopiie;turbo=1;user-id=20624989;user-type=staff :tmi.twitch.tv USERNOTICE #schmoopiie :Great stream -- keep it up!',
+    data: '@badges=staff/1,subscriber/6,turbo/1;color=#008000;display-name=Schmoopiie;emotes=;mod=0;msg-id=resub;msg-param-months=6;room-id=20624989;subscriber=0;system-msg=Schmoopiie\\shas\\ssubscribed\\sfor\\s6\\smonths!;login=schmoopiie;turbo=1;user-id=20624989;user-type=staff :tmi.twitch.tv USERNOTICE #schmoopiie :Great stream -- keep it up!',
     expected: [
         '#schmoopiie',
         'Schmoopiie',
         6,
         'Great stream -- keep it up!',
         {
-            badges: { broadcaster: '1', staff: '1', turbo: '1' },
-            'badges-raw': 'staff/1,broadcaster/1,turbo/1',
+            badges: { staff: '1', subscriber: '6', turbo: '1' },
+            'badges-raw': 'staff/1,subscriber/6,turbo/1',
             color: '#008000',
             'display-name': 'Schmoopiie',
             emotes: null,
@@ -233,8 +233,8 @@ var events = [{
             'msg-id': 'resub',
             'msg-param-months': '6',
             'room-id': '20624989',
-            subscriber: false,
-            'system-msg': 'Schmoopiieshasssubscribedsfors6smonths!',
+            subscriber: true,
+            'system-msg': 'Schmoopiie has subscribed for 6 months!',
             turbo: true,
             'user-id': '20624989',
             'user-type': 'staff'

--- a/test/events.js
+++ b/test/events.js
@@ -191,7 +191,17 @@ var events = [{
         '#schmoopiie',
         'Schmoopiie',
         6,
-        'Great stream -- keep it up!'
+        'Great stream -- keep it up!',
+        {
+            color: '#008000',
+            'display-name': 'Schmoopiie',
+            emotes: null,
+            mod: false,
+            'user-type': 'staff',
+            'emotes-raw': null,
+            username: 'schmoopiie',
+            'message-type': 'resub'
+        }
     ]
 }, {
     name: 'resub',
@@ -200,7 +210,18 @@ var events = [{
         '#schmoopiie',
         'Schmoopiie',
         6,
-        'Great stream -- keep it up!'
+        'Great stream -- keep it up!',
+        {
+            color: '#008000',
+            'display-name': 'Schmoopiie',
+            emotes: null,
+            mod: false,
+            'user-type': 'staff',
+            'emotes-raw': null,
+            username: 'schmoopiie',
+            'message-type': 'resub',
+            'msg-param-months': 6
+        }
     ]
 }, {
     name: 'subscribers',

--- a/test/events.js
+++ b/test/events.js
@@ -186,7 +186,7 @@ var events = [{
     ]
 }, {
     name: 'subanniversary',
-    data: '@badges=staff/1,subscriber/6,turbo/1;color=#008000;display-name=Schmoopiie;emotes=;mod=0;msg-id=resub;msg-param-months=6;room-id=20624989;subscriber=0;system-msg=Schmoopiie\\shas\\ssubscribed\\sfor\\s6\\smonths!;login=schmoopiie;turbo=1;user-id=20624989;user-type=staff :tmi.twitch.tv USERNOTICE #schmoopiie :Great stream -- keep it up!',
+    data: '@badges=staff/1,subscriber/6,turbo/1;color=#008000;display-name=Schmoopiie;emotes=;mod=0;msg-id=resub;msg-param-months=6;room-id=20624989;subscriber=1;system-msg=Schmoopiie\\shas\\ssubscribed\\sfor\\s6\\smonths!;login=schmoopiie;turbo=1;user-id=20624989;user-type=staff :tmi.twitch.tv USERNOTICE #schmoopiie :Great stream -- keep it up!',
     expected: [
         '#schmoopiie',
         'Schmoopiie',
@@ -206,7 +206,7 @@ var events = [{
             'msg-param-months': '6',
             'room-id': '20624989',
             subscriber: true,
-            'system-msg': 'Schmoopiie has subscribed for 6 months!',
+            'system-msg': 'Schmoopiie\\shas\\ssubscribed\\sfor\\s6\\smonths!',
             turbo: true,
             'user-id': '20624989',
             'user-type': 'staff'
@@ -214,7 +214,7 @@ var events = [{
     ]
 }, {
     name: 'resub',
-    data: '@badges=staff/1,subscriber/6,turbo/1;color=#008000;display-name=Schmoopiie;emotes=;mod=0;msg-id=resub;msg-param-months=6;room-id=20624989;subscriber=0;system-msg=Schmoopiie\\shas\\ssubscribed\\sfor\\s6\\smonths!;login=schmoopiie;turbo=1;user-id=20624989;user-type=staff :tmi.twitch.tv USERNOTICE #schmoopiie :Great stream -- keep it up!',
+    data: '@badges=staff/1,subscriber/6,turbo/1;color=#008000;display-name=Schmoopiie;emotes=;mod=0;msg-id=resub;msg-param-months=6;room-id=20624989;subscriber=1;system-msg=Schmoopiie\\shas\\ssubscribed\\sfor\\s6\\smonths!;login=schmoopiie;turbo=1;user-id=20624989;user-type=staff :tmi.twitch.tv USERNOTICE #schmoopiie :Great stream -- keep it up!',
     expected: [
         '#schmoopiie',
         'Schmoopiie',
@@ -234,7 +234,7 @@ var events = [{
             'msg-param-months': '6',
             'room-id': '20624989',
             subscriber: true,
-            'system-msg': 'Schmoopiie has subscribed for 6 months!',
+            'system-msg': 'Schmoopiie\\shas\\ssubscribed\\sfor\\s6\\smonths!',
             turbo: true,
             'user-id': '20624989',
             'user-type': 'staff'

--- a/test/events.js
+++ b/test/events.js
@@ -193,14 +193,23 @@ var events = [{
         6,
         'Great stream -- keep it up!',
         {
+            badges: { broadcaster: '1', staff: '1', turbo: '1' },
+            'badges-raw': 'staff/1,broadcaster/1,turbo/1',
             color: '#008000',
             'display-name': 'Schmoopiie',
             emotes: null,
-            mod: false,
-            'user-type': 'staff',
             'emotes-raw': null,
-            username: 'schmoopiie',
-            'message-type': 'resub'
+            login: 'schmoopiie',
+            'message-type': 'resub',
+            mod: false,
+            'msg-id': 'resub',
+            'msg-param-months': '6',
+            'room-id': '20624989',
+            subscriber: false,
+            'system-msg': 'Schmoopiie\\shas\\ssubscribed\\sfor\\s6\\smonths!',
+            turbo: true,
+            'user-id': '20624989',
+            'user-type': 'staff'
         }
     ]
 }, {
@@ -212,15 +221,23 @@ var events = [{
         6,
         'Great stream -- keep it up!',
         {
+            badges: { broadcaster: '1', staff: '1', turbo: '1' },
+            'badges-raw': 'staff/1,broadcaster/1,turbo/1',
             color: '#008000',
             'display-name': 'Schmoopiie',
             emotes: null,
-            mod: false,
-            'user-type': 'staff',
             'emotes-raw': null,
-            username: 'schmoopiie',
+            login: 'schmoopiie',
             'message-type': 'resub',
-            'msg-param-months': 6
+            mod: false,
+            'msg-id': 'resub',
+            'msg-param-months': '6',
+            'room-id': '20624989',
+            subscriber: false,
+            'system-msg': 'Schmoopiie\\shas\\ssubscribed\\sfor\\s6\\smonths!',
+            turbo: true,
+            'user-id': '20624989',
+            'user-type': 'staff'
         }
     ]
 }, {


### PR DESCRIPTION
After the discussion in #191, I've decided that the first option would be the most sane one. Just did it right here, added the userstate as fifth parameter to the resub events, to allow users to get the details of the message (emotes, display name, ...) without breaking backwards compatibility.

The tests didn't run at all on my machine, hope they are okay.