### PR TITLE
client: conditionally add proxy when using node.js web socket library

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -6,6 +6,8 @@ var parse = require("./parser");
 var timer = require("./timer");
 var ws = global.WebSocket || global.MozWebSocket || require("ws");
 var _ = require("./utils");
+var url = require("url");
+var httpsProxyAgent = require("https-proxy-agent");
 
 // Client instance..
 var client = function client(opts) {
@@ -868,7 +870,39 @@ client.prototype.connect = function connect() {
 
 // Open a connection..
 client.prototype._openConnection = function _openConnection() {
-    this.ws = new ws(`${this.secure ? "wss" : "ws"}://${this.server}:${this.port}/`, "irc");
+    var options;
+    if (global.WebSocket || global.MozWebSocket) {
+        options = "irc";
+    } else {
+        // Apply a proxy agent to the web socket if a proxy env exists and server does not exist in no_proxy
+        options = {};
+        var proxy = this.secure
+            ? process.env.https_proxy || process.env.HTTPS_PROXY
+            : process.env.http_proxy || process.env.HTTP_PROXY;
+
+        if (proxy) {
+            var noProxy = process.env.no_proxy || process.env.NO_PROXY;
+            if (noProxy) {
+                var noProxies = noProxy.split(',');
+                noProxy = false;
+                for (var i = 0; i < noProxies.length; i++) {
+                    noProxy = this.server === noProxies[i];
+                    if (noProxy) {
+                        break;
+                    }
+                }
+            }
+
+            if (!noProxy) {
+                this.log.info("Using proxy server "+ proxy);
+                var opts = url.parse(proxy);
+                opts.secureEndpoint = this.secure;
+                options.agent = new httpsProxyAgent(opts);
+            }
+        }
+    }
+
+    this.ws = new ws(`${this.secure ? "wss" : "ws"}://${this.server}:${this.port}/`, options);
 
     this.ws.onmessage = this._onMessage.bind(this);
     this.ws.onerror = this._onError.bind(this);

--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
   },
   "dependencies": {
     "request": "2.74.0",
-    "ws": "1.0.1"
+    "ws": "1.0.1",
+    "https-proxy-agent": "^1.0.0"
   },
   "devDependencies": {
     "babel-preset-es2015": "6.6.0",


### PR DESCRIPTION
If using the node.js web socket library check the env for proxy variables. If found and applicable apply.

Note - This would add an additional dependency to https-proxy-agent.
