### PR TITLE
Add capitalised alias to client constructor.

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,5 +9,6 @@ String.prototype.includes || (String.prototype.includes = function() {
 });
 
 module.exports={
-	client:require("./lib/client")
+	client:require("./lib/client"),
+    Client:require("./lib/client")
 };

--- a/index.js
+++ b/index.js
@@ -10,5 +10,5 @@ String.prototype.includes || (String.prototype.includes = function() {
 
 module.exports={
 	client:require("./lib/client"),
-    Client:require("./lib/client")
+	Client:require("./lib/client")
 };


### PR DESCRIPTION
I'd like to have the client constructor with a capital `c` so I can use this in a project that requires constructors to begin with a capital letter. (StandardJS)

I left the lower-case constructor in so it won't break anybody's projects.

Thanks.