### PR TITLE
client: subscription handling changed from twitchnotify to usernotice

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -578,7 +578,7 @@ client.prototype.handleMessage = function handleMessage(message) {
                         var username = message.tags["display-name"] || message.tags["login"];
                         var plan = message.tags["msg-param-sub-plan"];
                         var planName = message.tags["msg-param-sub-plan-name"];
-                        var prime = subPlan.includes("Prime");
+                        var prime = plan.includes("Prime");
                         var userstate = null;
 
                         if (msg) {

--- a/lib/client.js
+++ b/lib/client.js
@@ -558,8 +558,10 @@ client.prototype.handleMessage = function handleMessage(message) {
                 case "USERNOTICE":
                     if (msgid === "resub") {
                         var username = message.tags["display-name"] || message.tags["login"];
+                        var plan = message.tags["msg-param-sub-plan"];
+                        var planName = message.tags["msg-param-sub-plan-name"];
                         var months = _.get(~~message.tags["msg-param-months"], null);
-                        var prime = message.tags["system-msg"].includes('Twitch\\sPrime');
+                        var prime = plan.includes("Prime");
                         var userstate = null;
 
                         if (msg) {
@@ -568,8 +570,8 @@ client.prototype.handleMessage = function handleMessage(message) {
                         }
 
                         this.emits(["resub", "subanniversary"], [
-                            [channel, username, months, msg, userstate, { prime: prime }],
-                            [channel, username, months, msg, userstate, { prime: prime }]
+                            [channel, username, months, msg, userstate, {prime, plan, planName}],
+                            [channel, username, months, msg, userstate, {prime, plan, planName}]
                         ]);
                     }
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -572,6 +572,22 @@ client.prototype.handleMessage = function handleMessage(message) {
                             [channel, username, months, msg, userstate, { prime: prime }]
                         ]);
                     }
+
+                    // Handle sub
+                    else if (msgid == "sub") {
+                        var username = message.tags["display-name"] || message.tags["login"];
+                        var plan = message.tags["msg-param-sub-plan"];
+                        var planName = message.tags["msg-param-sub-plan-name"];
+                        var prime = subPlan.includes("Prime");
+                        var userstate = null;
+
+                        if (msg) {
+                            userstate = message.tags;
+                            userstate['message-type'] = 'sub';
+                        }
+
+                        this.emit("subscription", channel, username, {prime, plan, planName}, msg, userstate);
+                    }
                     break;
 
                 // Channel is now hosting another channel or exited host mode..
@@ -811,19 +827,9 @@ client.prototype.handleMessage = function handleMessage(message) {
                 case "PRIVMSG":
                     // Add username (lowercase) to the tags..
                     message.tags.username = message.prefix.split("!")[0];
-                    if (message.tags.username === "twitchnotify") {
-                        // Someone subscribed to a hosted channel. Who cares.
-                        if (msg.includes("subscribed to")) {
-                          // Ignore this feature.
-                        }
-
-                        else if (msg.includes("just subscribed")) {
-                            this.emit("subscription", channel, msg.split(" ")[0], { prime: msg.includes("Twitch Prime!") });
-                        }
-                    }
 
                     // Message from JTV..
-                    else if (message.tags.username === "jtv") {
+                    if (message.tags.username === "jtv") {
                         // Someone is hosting the channel and the message contains how many viewers..
                         if (msg.includes("hosting you for")) {
                             var count = _.extractNumber(msg);

--- a/test/events.js
+++ b/test/events.js
@@ -256,10 +256,36 @@ var events = [{
     ]
 }, {
     name: 'subscription',
-    data: ':twitchnotify!twitchnotify@twitchnotify.tmi.twitch.tv PRIVMSG #schmoopiie :schmoopiie just subscribed!',
+    data: '@badges=staff/1,subscriber/1,turbo/1;color=#008000;display-name=Schmoopiie;emotes=;mod=0;msg-id=sub;room-id=20624989;subscriber=1;msg-param-sub-plan=Prime;msg-param-sub-plan-name=Channel\\sSubscription\\s(Schmoopiie);system-msg=Schmoopiie\\sjust\\ssubscribed!;login=schmoopiie;turbo=1;user-id=20624989;user-type=staff :tmi.twitch.tv USERNOTICE #schmoopiie :Great stream -- keep it up!',
     expected: [
         '#schmoopiie',
-        'schmoopiie'
+        'schmoopiie',
+        {
+          'prime': true,
+          'plan': 'Prime',
+          'planName': 'Channel\\sSubscription\\s(Schmoopiie)'
+        }
+        'Great stream -- keep it up!',
+        {
+            badges: { staff: '1', subscriber: '1', turbo: '1' },
+            'badges-raw': 'staff/1,subscriber/1,turbo/1',
+            color: '#008000',
+            'display-name': 'Schmoopiie',
+            emotes: null,
+            'emotes-raw': null,
+            login: 'schmoopiie',
+            'message-type': 'sub',
+            mod: false,
+            'msg-id': 'sub',
+            'msg-param-sub-plan': 'Prime',
+            'msg-param-sub-plan-name': 'Channel\\sSubscription\\s(Schmoopiie)',
+            'room-id': '20624989',
+            subscriber: true,
+            'system-msg': 'Schmoopiie\\sjust\\ssubscribed!',
+            turbo: true,
+            'user-id': '20624989',
+            'user-type': 'staff'
+        }
     ]
 }, {
     name: 'timeout',

--- a/test/events.js
+++ b/test/events.js
@@ -186,7 +186,7 @@ var events = [{
     ]
 }, {
     name: 'subanniversary',
-    data: '@badges=staff/1,subscriber/6,turbo/1;color=#008000;display-name=Schmoopiie;emotes=;mod=0;msg-id=resub;msg-param-months=6;room-id=20624989;subscriber=1;system-msg=Schmoopiie\\shas\\ssubscribed\\sfor\\s6\\smonths!;login=schmoopiie;turbo=1;user-id=20624989;user-type=staff :tmi.twitch.tv USERNOTICE #schmoopiie :Great stream -- keep it up!',
+    data: '@badges=staff/1,subscriber/6,turbo/1;color=#008000;display-name=Schmoopiie;emotes=;mod=0;msg-id=resub;msg-param-months=6;room-id=20624989;subscriber=1;msg-param-sub-plan=Prime;msg-param-sub-plan-name=Channel\\sSubscription\\s(Schmoopiie);system-msg=Schmoopiie\\shas\\ssubscribed\\sfor\\s6\\smonths!;login=schmoopiie;turbo=1;user-id=20624989;user-type=staff :tmi.twitch.tv USERNOTICE #schmoopiie :Great stream -- keep it up!',
     expected: [
         '#schmoopiie',
         'Schmoopiie',
@@ -204,17 +204,24 @@ var events = [{
             mod: false,
             'msg-id': 'resub',
             'msg-param-months': '6',
+            'msg-param-sub-plan': 'Prime',
+            'msg-param-sub-plan-name': 'Channel\\sSubscription\\s(Schmoopiie)',
             'room-id': '20624989',
             subscriber: true,
             'system-msg': 'Schmoopiie\\shas\\ssubscribed\\sfor\\s6\\smonths!',
             turbo: true,
             'user-id': '20624989',
             'user-type': 'staff'
+        },
+        {
+          'prime': true,
+          'plan': 'Prime',
+          'planName': 'Channel\\sSubscription\\s(Schmoopiie)'
         }
     ]
 }, {
     name: 'resub',
-    data: '@badges=staff/1,subscriber/6,turbo/1;color=#008000;display-name=Schmoopiie;emotes=;mod=0;msg-id=resub;msg-param-months=6;room-id=20624989;subscriber=1;system-msg=Schmoopiie\\shas\\ssubscribed\\sfor\\s6\\smonths!;login=schmoopiie;turbo=1;user-id=20624989;user-type=staff :tmi.twitch.tv USERNOTICE #schmoopiie :Great stream -- keep it up!',
+    data: '@badges=staff/1,subscriber/6,turbo/1;color=#008000;display-name=Schmoopiie;emotes=;mod=0;msg-id=resub;msg-param-months=6;room-id=20624989;subscriber=1;msg-param-sub-plan=Prime;msg-param-sub-plan-name=Channel\\sSubscription\\s(Schmoopiie);system-msg=Schmoopiie\\shas\\ssubscribed\\sfor\\s6\\smonths!;login=schmoopiie;turbo=1;user-id=20624989;user-type=staff :tmi.twitch.tv USERNOTICE #schmoopiie :Great stream -- keep it up!',
     expected: [
         '#schmoopiie',
         'Schmoopiie',
@@ -232,13 +239,20 @@ var events = [{
             mod: false,
             'msg-id': 'resub',
             'msg-param-months': '6',
+            'msg-param-sub-plan': 'Prime',
+            'msg-param-sub-plan-name': 'Channel\\sSubscription\\s(Schmoopiie)',
             'room-id': '20624989',
             subscriber: true,
             'system-msg': 'Schmoopiie\\shas\\ssubscribed\\sfor\\s6\\smonths!',
             turbo: true,
             'user-id': '20624989',
             'user-type': 'staff'
-        }
+        },
+        {
+          'prime': true,
+          'plan': 'Prime',
+          'planName': 'Channel\\sSubscription\\s(Schmoopiie)'
+        },
     ]
 }, {
     name: 'subscribers',

--- a/test/events.js
+++ b/test/events.js
@@ -259,12 +259,12 @@ var events = [{
     data: '@badges=staff/1,subscriber/1,turbo/1;color=#008000;display-name=Schmoopiie;emotes=;mod=0;msg-id=sub;room-id=20624989;subscriber=1;msg-param-sub-plan=Prime;msg-param-sub-plan-name=Channel\\sSubscription\\s(Schmoopiie);system-msg=Schmoopiie\\sjust\\ssubscribed!;login=schmoopiie;turbo=1;user-id=20624989;user-type=staff :tmi.twitch.tv USERNOTICE #schmoopiie :Great stream -- keep it up!',
     expected: [
         '#schmoopiie',
-        'schmoopiie',
+        'Schmoopiie',
         {
           'prime': true,
           'plan': 'Prime',
           'planName': 'Channel\\sSubscription\\s(Schmoopiie)'
-        }
+        },
         'Great stream -- keep it up!',
         {
             badges: { staff: '1', subscriber: '1', turbo: '1' },


### PR DESCRIPTION
Addressing: https://github.com/tmijs/tmi.js/issues/222
According to
https://discuss.dev.twitch.tv/t/subscriptions-beta-changes/10023
New subscriptions are now handled as a USERNOTICE similarly to resubs,
and the method object can now include a plan and planName.

Additionally, users can now provide a message upon subscribing, so a msg
and userstate is now provided. This is a lot of parameters, but it
should be backwards compatible with any code that was designed for the
old twitchnotify version.