### PR TITLE
Should fix the UnhandledPromiseRejectionWarning #201 #225 #227 #229

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -1037,9 +1037,10 @@ client.prototype._getPromiseDelay = function _getPromiseDelay() {
 // Send command to server or channel..
 client.prototype._sendCommand = function _sendCommand(delay, channel, command, fn) {
     // Race promise against delay..
-    return new Promise((resolve, reject) => {
-        _.promiseDelay(delay).then(() => { reject("No response from Twitch."); });
-
+    var timeout = new Promise((resolve, reject) => {
+        _.promiseDelay(delay).then(() => { reject("No response from Twitch."); })
+    });
+    var promise = new Promise((resolve, reject) => {
         // Make sure the socket is opened..
         if (!_.isNull(this.ws) && this.ws.readyState !== 2 && this.ws.readyState !== 3) {
             // Executing a command on a channel..
@@ -1055,11 +1056,12 @@ client.prototype._sendCommand = function _sendCommand(delay, channel, command, f
             }
             fn(resolve, reject);
         }
-
         // Disconnected from server..
         else { reject("Not connected to server."); }
     });
-};
+
+    return Promise.race([timeout, promise]);
+}
 
 // Send a message to channel..
 client.prototype._sendMessage = function _sendMessage(delay, channel, message, fn) {


### PR DESCRIPTION
I need some people to test this change and if everything goes well, I will land it on v1.2.2. I know that we will need polyfills for browser support and for backward compatibility for Node < 6. The main goal is to fix this deprecation warning when using Node 6, 7 and 8 (which is scheduled to be released on May 30, 2017).