### PR TITLE
Add some msg_ids on notice event listeners

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -514,6 +514,14 @@ client.prototype.handleMessage = function handleMessage(message) {
                         case "msg_ratelimit":
                         case "msg_subsonly":
                         case "msg_timedout":
+                        case "msg_bad_characters" :
+                        case "msg_channel_blocked" :                        
+                        case "msg_facebook":                        
+                        case "msg_followersonly_followed":                        
+                        case "msg_followersonly_zero":
+                        case "msg_rejected":
+                        case "msg_slowmode":
+                        case "msg_suspended":
                         case "no_help":
                         case "usage_disconnect":
                         case "usage_help":

--- a/lib/client.js
+++ b/lib/client.js
@@ -514,10 +514,10 @@ client.prototype.handleMessage = function handleMessage(message) {
                         case "msg_ratelimit":
                         case "msg_subsonly":
                         case "msg_timedout":
-                        case "msg_bad_characters" :
-                        case "msg_channel_blocked" :                        
-                        case "msg_facebook":                        
-                        case "msg_followersonly_followed":                        
+                        case "msg_bad_characters":
+                        case "msg_channel_blocked":
+                        case "msg_facebook":
+                        case "msg_followersonly_followed":
                         case "msg_followersonly_zero":
                         case "msg_rejected":
                         case "msg_slowmode":


### PR DESCRIPTION
Add some msgids on notice event listeners (referenced : https://dev.twitch.tv/docs/irc/msg-id/)
These msgids are not processed on tmi.js 1.2.1, and make warn logs.
Handling of msgid, 'msg_rejected_mandatory' is on [here ](https://github.com/tmijs/tmi.js/pull/273) .(already pulled) . 