### PR TITLE
Check websocket connecting readyState

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -157,7 +157,7 @@ client.prototype.handleMessage = function handleMessage(message) {
                 // Set an internal ping timeout check interval..
                 this.pingLoop = setInterval(() => {
                     // Make sure the connection is opened before sending the message..
-                    if (!_.isNull(this.ws) && this.ws.readyState !== 2 && this.ws.readyState !== 3) {
+                    if (!_.isNull(this.ws) && self.ws.readyState !== 0 && this.ws.readyState !== 2 && this.ws.readyState !== 3) {
                         this.ws.send("PING");
                     }
                     this.latency = new Date();
@@ -181,7 +181,7 @@ client.prototype.handleMessage = function handleMessage(message) {
                 for (var i = 0; i < joinChannels.length; i++) {
                     var self = this;
                     joinQueue.add(function(i) {
-                        if (!_.isNull(self.ws) && self.ws.readyState !== 2 && self.ws.readyState !== 3) {
+                        if (!_.isNull(self.ws) && self.ws.readyState !== 0 && self.ws.readyState !== 2 && self.ws.readyState !== 3) {
                             self.ws.send(`JOIN ${_.channel(joinChannels[i])}`);
                         }
                     }.bind(this, i))


### PR DESCRIPTION
On reconnects with large numbers of channels, the queue join can mess up and try to send WS messages before the state is actually set to "CONNECTED" causing a crash. This PR checks for "CONNECTING" states.

Related issue: https://github.com/tmijs/tmi.js/issues/217