### PR TITLE
Always use xhr for api requests

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -15,8 +15,8 @@ var api = function api(options, callback) {
 		var opts = _.merge({ method: "GET", json: true }, options, { url });
 		request(opts, callback);
 	}
-	// Inside an extension -> we cannot use jsonp!
-	else if(_.isExtension() || _.isReactNative()) {
+	// Web application, extension, React Native etc.
+	else {
 		options = _.merge({ url, method: "GET", headers: {} }, options);
 		// prepare request
 		var xhr = new XMLHttpRequest();
@@ -38,21 +38,6 @@ var api = function api(options, callback) {
 		});
 		// submit
 		xhr.send();
-	}
-	// Inside a web application, use jsonp..
-	else {
-		var script = document.createElement("script");
-		// Callbacks must match the regex [a-zA-Z_$][\w$]*(\.[a-zA-Z_$][\w$]*)*
-		var callbackName = `jsonp_callback_${Math.round(100000 * Math.random())}`;
-		window[callbackName] = function(data) {
-			delete window[callbackName];
-			document.body.removeChild(script);
-			callback(null, null, data);
-		};
-
-		// Inject the script in the document..
-		script.src = `${url}${url.includes("?") ? "&" : "?"}callback=${callbackName}`;
-		document.body.appendChild(script);
 	}
 }
 

--- a/lib/api.js
+++ b/lib/api.js
@@ -17,7 +17,7 @@ var api = function api(options, callback) {
 	}
 	// Web application, extension, React Native etc.
 	else {
-		options = _.merge({ url, method: "GET", headers: {} }, options);
+		options = _.merge({ method: "GET", headers: {} }, options, { url });
 		// prepare request
 		var xhr = new XMLHttpRequest();
 		xhr.open(options.method, options.url, true);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -123,22 +123,6 @@ var self = module.exports = {
 		return false;
 	},
 
-	// Return whether inside a Chrome extension or not..
-	isExtension: () => {
-		try {
-			return window.chrome && chrome.runtime && chrome.runtime.id;
-		} catch(e) {}
-		return false;
-	},
-
-	// Return whether inside a React Native app..
-	isReactNative: () => {
-		try {
-			return navigator && navigator.product == "ReactNative";
-		} catch(e) {}
-		return false;
-	},
-
 	// Merge two objects..
 	merge: Object.assign,
 


### PR DESCRIPTION
The only API request `/chat/emoticon_images` requires headers and there's no way to add headers with the script injection.