### PR TITLE
client: fix MaxListeners before override by EventEmitter

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -10,7 +10,6 @@ var _ = require("./utils");
 // Client instance..
 var client = function client(opts) {
 	if(this instanceof client === false) { return new client(opts); }
-	this.setMaxListeners(0);
 
 	this.opts = _.get(opts, {});
 	this.opts.channels = this.opts.channels || [];
@@ -63,6 +62,7 @@ var client = function client(opts) {
 	});
 
 	eventEmitter.call(this);
+	this.setMaxListeners(0);
 }
 
 _.inherits(client, eventEmitter);


### PR DESCRIPTION
The constructor of the EventEmtiter (events.js) overrides the _maxListeners variable if its 0 or undefined or smth else. Due to calling the EventEmitter constructor after setMaxListerns(0) makes line 13 completely useless.

Disables the should allready disabled "warning: possible EventEmitter memory leak detected. 11 listeners added. Use emitter.setMaxListeners() to increase limit." message.