### PR TITLE
change connection.secure to be true by default

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -29,7 +29,7 @@ var client = function client(opts) {
 	this.reconnections = 0;
 	this.reconnectTimer = this.reconnectInterval;
 
-	this.secure = _.get(this.opts.connection.secure, false);
+	this.secure = _.get(this.opts.connection.secure, true);
 
 	// Raw data and object for emote-sets..
 	this.emotes = "";


### PR DESCRIPTION
This PR sets the `connection.secure` option to true by default.

This shouldn't break any existing code - just make it more secure if it relies on the default setting.

I'm not sure about the structure of the documentation, and it hasn't been updated in a while, so I keep that as an excercise for the reader 😉 