### PR TITLE
client.whisper() now rejects

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -583,7 +583,8 @@ client.prototype.handleMessage = function handleMessage(message) {
 							"_promiseSubscribers",
 							"_promiseSubscribersoff",
 							"_promiseEmoteonly",
-							"_promiseEmoteonlyoff"
+							"_promiseEmoteonlyoff",
+							"_promiseWhisper"
 						], [noticeArr, [msgid, channel]]);
 						break;
 

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -544,6 +544,16 @@ module.exports = {
 
 		// Send the command to the server and race the Promise against a delay..
 		return this._sendCommand(this._getPromiseDelay(), "#tmijs", `/w ${username} ${message}`, (resolve, reject) => {
+			this.once("_promiseWhisper", (err) => {
+				if (err) { reject(err); }
+			});
+		}).catch((error) => {
+			// Either an "actual" error occured or the timeout triggered
+			// the latter means no errors have occured and we can resolve
+			// else just elevate the error
+			if (error !== "No response from Twitch.") {
+				throw error;
+			}
 			var from = _.channel(username),
 				userstate = _.merge({
 						"message-type": "whisper",
@@ -557,10 +567,7 @@ module.exports = {
 				[from, userstate, message, true],
 				[from, userstate, message, true]
 			]);
-
-			// At this time, there is no possible way to detect if a message has been sent has been eaten
-			// by the server, so we can only resolve the Promise.
-			resolve([username, message]);
+			return [username, message];
 		});
 	}
 }

--- a/test/commands.js
+++ b/test/commands.js
@@ -398,7 +398,10 @@ var tests = [{
 	inputParams: ['moddymcmodface', 'You got unmodded! D:'],
 	returnedParams: ['moddymcmodface', 'You got unmodded! D:'],
 	serverTest: '/w',
-	serverCommand: ':tmi.twitch.tv WHISPER moddymcmodface :You got unmodded! D:'
+	serverCommand: ':tmi.twitch.tv WHISPER moddymcmodface :You got unmodded! D:',
+	errorCommands: [
+		no_permission,
+	]
 }];
 
 describe('commands (justinfan)', function() {


### PR DESCRIPTION
`client.whisper()` now rejects, for now only when one of the following notices arrive within the `_getPromiseDelay()` time-span: 

* `no_permission`
* `whisper_invalid_login`
* `whisper_invalid_self`
* `whisper_limit_per_min`
* `whisper_limit_per_sec`
* `whisper_restricted`
* `whisper_restricted_recipient`

This closes #388 
This is a breaking change