### PR TITLE
Fix moderator tracking for USERSTATE messages

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -823,11 +823,11 @@ client.prototype.handleMessage = function handleMessage(message) {
 
 				// Add the client to the moderators of this room..
 				if(message.tags["user-type"] === "mod") {
-					if(!this.moderators[this.lastJoined]) {
-						this.moderators[this.lastJoined] = [];
+					if(!this.moderators[channel]) {
+						this.moderators[channel] = [];
 					}
-					if(!this.moderators[this.lastJoined].includes(this.username)) {
-						this.moderators[this.lastJoined].push(this.username);
+					if(!this.moderators[channel].includes(this.username)) {
+						this.moderators[channel].push(this.username);
 					}
 				}
 


### PR DESCRIPTION
The USERSTATE message contains the channel that it's
being sent for but this was not being used. Instead it used
the `this.lastJoined` variable. However, this internal variable
is only updated after the tracking for moderators is completed.

This results in moderator status being assigned to the wrong 
channel and will result in `client.isMod` returning `false` when 
called in an `onJoin` handler (or thereafter).