### PR TITLE
Add Accept header to emoticon_images request

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -1373,6 +1373,7 @@ client.prototype._updateEmoteset = function _updateEmoteset(sets) {
 		this.api({
 			url: `/chat/emoticon_images?emotesets=${sets}`,
 			headers: {
+				"Accept": "application/vnd.twitchtv.v5+json",
 				"Authorization": `OAuth ${_.token(token)}`,
 				"Client-ID": this.clientId
 			}


### PR DESCRIPTION
Without this header, Kraken defaults to V3 which is now deprecated:

`{"error":"Gone","status":410,"message":"v3 is a lie but v5 is still alive. See https://dev.twitch.tv/docs"}`