### PR TITLE
Assume connection success on MOTD end, not MOTD line

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -162,7 +162,7 @@ client.prototype.handleMessage = function handleMessage(message) {
 				break;
 
 			// Connected to server..
-			case "372":
+			case "376":
 				this.log.info("Connected to server.");
 				this.userstate[this._globalDefaultChannel] = {};
 				this.emits(["connected", "_promiseConnect"], [[this.server, this.port], [null]]);

--- a/lib/client.js
+++ b/lib/client.js
@@ -151,8 +151,8 @@ client.prototype.handleMessage = function handleMessage(message) {
 			case "002":
 			case "003":
 			case "004":
+			case "372":
 			case "375":
-			case "376":
 			case "CAP":
 				break;
 

--- a/test/events.js
+++ b/test/events.js
@@ -135,7 +135,7 @@ var events = [{
 	]
 }, {
 	name: 'connected',
-	data: ':tmi.twitch.tv 372 schmoopiie :You are in a maze of twisty passages, all alike.'
+	data: ':tmi.twitch.tv 376 schmoopiie :>'
 }, {
 	name: 'emotesets',
 	data: '@color=#1E90FF;display-name=Schmoopiie;emote-sets=0;turbo=0;user-type= :tmi.twitch.tv GLOBALUSERSTATE',

--- a/test/noop.js
+++ b/test/noop.js
@@ -5,7 +5,7 @@ var tests = [
 	':tmi.twitch.tv 003',
 	':tmi.twitch.tv 004',
 	':tmi.twitch.tv 375',
-	':tmi.twitch.tv 376',
+	':tmi.twitch.tv 372 schmoopiie :You are in a maze of twisty passages.',
 	':tmi.twitch.tv CAP',
 	'@msg-id=host_on :tmi.twitch.tv NOTICE #schmoopiie',
 	'@msg-id=host_off :tmi.twitch.tv NOTICE #schmoopiie',


### PR DESCRIPTION
Alternative servers send multiple MOTD lines, which is totally fine by the IRC spec, but makes tmi.js emit the connected event (and try to join channels) multiple times.