### PR TITLE
Ensure type of msg is string in unescapeIRC

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -67,7 +67,7 @@ var self = module.exports = {
 
 	// Escaping values:
 	// http://ircv3.net/specs/core/message-tags-3.2.html#escaping-values
-	unescapeIRC: msg => !msg || !msg.includes('\\') ?
+	unescapeIRC: msg => !msg || typeof msg !== 'string' || !msg.includes('\\') ?
 		msg :
 		msg.replace(
 			unescapeIRCRegex,


### PR DESCRIPTION
Fixes #443

This ensures that the type of `msg` is `string` before attempting to parse it in `unescapeIRC`.
Otherwise it leads to an error like "TypeError: msg.includes is not a function at Object.unescapeIRC " when `msg-param-sub-plan` is coerced to a type other than string by a call to `_.get` further up the stack, thus crashing the client.