### PR TITLE
client: update notice msg-ids

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -307,8 +307,10 @@ class Client extends EventEmitter {
 						// Ban command failed..
 						case 'already_banned':
 						case 'bad_ban_admin':
+						case 'bad_ban_anon':
 						case 'bad_ban_broadcaster':
 						case 'bad_ban_global_mod':
+						case 'bad_ban_mod':
 						case 'bad_ban_self':
 						case 'bad_ban_staff':
 						case 'usage_ban':
@@ -507,9 +509,11 @@ class Client extends EventEmitter {
 						// Timeout command failed..
 						case 'usage_timeout':
 						case 'bad_timeout_admin':
+						case 'bad_timeout_anon':
 						case 'bad_timeout_broadcaster':
 						case 'bad_timeout_duration':
 						case 'bad_timeout_global_mod':
+						case 'bad_timeout_mod':
 						case 'bad_timeout_self':
 						case 'bad_timeout_staff':
 							this.log.info(basicLog);


### PR DESCRIPTION
Added some NOTICE msg-ids not currently included:
```
bad_ban_anon
bad_ban_mod
bad_timeout_anon
bad_timeout_mod
```

Allows `ban` and `timeout` commands to be rejected with correct error msg instead of request timeout ("No response from Twitch.")

Reference: https://dev.twitch.tv/docs/irc/msg-id/