### PR TITLE
Client should check wasCloseCalled flag on error before reconnecting

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -1223,11 +1223,11 @@ class Client extends EventEmitter {
 		this.emits([ '_promiseConnect', 'disconnected' ], [ [ this.reason ] ]);
 
 		// Reconnect to server..
-		if(this.reconnect && this.reconnections === this.maxReconnectAttempts) {
+		if(!this.wasCloseCalled && this.reconnect && this.reconnections === this.maxReconnectAttempts) {
 			this.emit('maxreconnect');
 			this.log.error('Maximum reconnection attempts reached.');
 		}
-		if(this.reconnect && !this.reconnecting && this.reconnections <= this.maxReconnectAttempts - 1) {
+		if(!this.wasCloseCalled && this.reconnect && !this.reconnecting && this.reconnections <= this.maxReconnectAttempts - 1) {
 			this.reconnecting = true;
 			this.reconnections = this.reconnections + 1;
 			this.log.error(`Reconnecting in ${Math.round(this.reconnectTimer / 1000)} seconds..`);


### PR DESCRIPTION
If error occurs while disconnecting, client tries to reconnect.
This happens when disconnect() is called before connection is complete as below.

```
const client = new tmi.Client({
  options: { debug: true }
});
client.connect().catch(console.error);
client.disconnect()
```

I'm not sure if there are any other cases that disconnect() causes error,
but client should check to see if the user is trying to disconnect, I think