### PR TITLE
api: prefer global fetch() when available

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -1,4 +1,5 @@
-const fetch = require('node-fetch');
+const _global = typeof global !== 'undefined' ? global : typeof window !== 'undefined' ? window : {};
+const _fetch = _global.fetch || require('node-fetch');
 const _ = require('./utils');
 
 module.exports = function api(options, callback) {


### PR DESCRIPTION
This updates `api.js` to prefer the global `fetch()` over `node-fetch`, when available (similar to `client.js`)

This came up in an issue in [Astro #3608](https://github.com/withastro/astro/issues/3608), hope you don't mind me jumping in with a quick PR here!