### PR TITLE
Fix part() not processing channel name

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -130,6 +130,7 @@ class Client extends ClientBase {
 		});
 	}
 	part(channel) {
+		channel = _.channel()
 		return this._sendCommand({ delay: null, channel: null, command: `PART ${channel}` }, (res, rej) =>
 			this.once('_promisePart', err => !err ? res([ _.channel(channel) ]) : rej(err))
 		);


### PR DESCRIPTION
`part(channel)` is not properly processing channel names before sending PART commands to Twitch, resulting in PARTs failing to go through. This pull request will add the missing call to `_.channel()` ensuring that `client.part('a_random_lemurian')` (note the missing `#`) works just like `client.part('#a_random_lemurian')`.

```js
part(channel) {
    channel = _.channel() // This line of code should have been added
    return this._sendCommand({ delay: null, channel: null, command: `PART ${channel}` }, (res, rej) =>
        this.once('_promisePart', err => !err ? res([ _.channel(channel) ]) : rej(err))
    );
}
```
